### PR TITLE
limit cpu resources

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.4"
 services:
 
   mumble:
@@ -13,12 +13,21 @@ services:
     environment:
       TZ: Europe/Berlin
     restart: unless-stopped
-
+    # resources
+    cpus: 0.5
+    mem_limit: 256m
+    memswap_limit: 0
+    
   botamusique:
     image: docker.pkg.github.com/flipdot/mumble-docker/botamusique:latest
-    #build: plugins/botamusique-docker/.
+    # build: plugins/botamusique-docker/.
     volumes:
       - ./data/botamusique:/data/
     depends_on:
       - mumble
     restart: unless-stopped
+    # resources
+    cpus: 1
+    oom_score_adj: 100 # kill this thing first
+    mem_limit: 256m
+    memswap_limit: 0


### PR DESCRIPTION
TODO: there's a bug somewhere which makes botamusique spin 100% CPU for
~2 minutes when downloading youtube videos. Fix that.

I'd vote for fixing that bug first before deploying this again. @HerHde might know?